### PR TITLE
feat: add insert-wikilink action to link browser and GTD board

### DIFF
--- a/lua/holon/gtd/board.lua
+++ b/lua/holon/gtd/board.lua
@@ -843,6 +843,14 @@ local function setup_keymaps(buf)
   -- Add task
   vim.keymap.set("n", "a", function() add_task() end, opts)
 
+  -- Insert link
+  vim.keymap.set("n", "l", function()
+    M.close()
+    vim.schedule(function()
+      require("holon.zk.pickers").insert_link_picker()
+    end)
+  end, opts)
+
   -- Timeline scale
   vim.keymap.set("n", "w", function() set_timeline_scale("w") end, opts)
   vim.keymap.set("n", "m", function() set_timeline_scale("m") end, opts)

--- a/lua/holon/gtd/render.lua
+++ b/lua/holon/gtd/render.lua
@@ -261,13 +261,13 @@ function M.render_helpline(buf, state)
   local scale_label = state.timeline_scale == "w" and "w/m:month" or "w/m:week"
   local help
   if state.view_mode == "inbox" then
-    help = " j/k:select  C-j/k:panel  CR:open  p:promote  dd:delete  a:add  I:back  H:horizon  D:done  q:close"
+    help = " j/k:select  C-j/k:panel  CR:open  p:promote  dd:delete  a:add  l:link  I:back  H:horizon  D:done  q:close"
   elseif state.view_mode == "done" then
-    help = " j/k:select  C-j/k:panel  CR:open  r:restore  I:inbox  H:horizon  D:back  q:close"
+    help = " j/k:select  C-j/k:panel  CR:open  r:restore  l:link  I:inbox  H:horizon  D:back  q:close"
   elseif state.view_mode == "horizon" then
-    help = " j/k:select  C-j/k:panel  Tab:mark  p:move  b:block  CR:open  c:status  t:target  s:start  a:add  " .. scale_label .. "  g:preview  H:back  I:inbox  D:done  q:close"
+    help = " j/k:select  C-j/k:panel  Tab:mark  p:move  b:block  CR:open  c:status  t:target  s:start  a:add  l:link  " .. scale_label .. "  g:preview  H:back  I:inbox  D:done  q:close"
   else
-    help = " j/k:select  C-j/k:panel  Tab:mark  p:move  b:block  CR:open  c:status  t:target  s:start  a:add  " .. scale_label .. "  g:preview  H:horizon  I:inbox  D:done  q:close"
+    help = " j/k:select  C-j/k:panel  Tab:mark  p:move  b:block  CR:open  c:status  t:target  s:start  a:add  l:link  " .. scale_label .. "  g:preview  H:horizon  I:inbox  D:done  q:close"
   end
 
   utils.buf_set_lines(buf, { help })

--- a/lua/holon/zk/link_browser.lua
+++ b/lua/holon/zk/link_browser.lua
@@ -222,7 +222,7 @@ local function render_helpline()
   local b = browser
   local depth = #b.state.history
   local back_label = depth > 0 and "-:back(" .. depth .. ")" or ""
-  local help = " j/k:select  b:backlinks  f:forward  t:tags  CR:dive  " .. back_label .. "  o:open  q:close"
+  local help = " j/k:select  b:backlinks  f:forward  t:tags  CR:dive  " .. back_label .. "  o:open  l:link  q:close"
 
   utils.buf_set_lines(b.bufs.helpline, { help })
 
@@ -413,6 +413,12 @@ function M.open(filepath)
   vim.keymap.set("n", "f", function() switch_mode("forward") end, opts)
   vim.keymap.set("n", "t", function() switch_mode("tags") end, opts)
   vim.keymap.set("n", "o", function() open_note() end, opts)
+  vim.keymap.set("n", "l", function()
+    M.close()
+    vim.schedule(function()
+      require("holon.zk.pickers").insert_link_picker()
+    end)
+  end, opts)
   vim.keymap.set("n", "q", function() M.close() end, opts)
   vim.keymap.set("n", "<Esc>", function() M.close() end, opts)
 

--- a/lua/holon/zk/pickers.lua
+++ b/lua/holon/zk/pickers.lua
@@ -296,6 +296,27 @@ function M.templates(opts)
   })
 end
 
+--- Insert link picker - find a note and insert its wikilink at the current cursor position
+---@param opts table|nil Options
+function M.insert_link_picker(opts)
+  opts = opts or {}
+  local raw = finders.find_notes(opts)
+  local entry_maker = make_entry.make_note_entry(opts)
+  local items = build_items(raw, entry_maker)
+
+  picker.open({
+    title = "Holon: Insert Link",
+    items = items,
+    format_item = format_item,
+    get_ordinal = function(item) return item.ordinal end,
+    on_select = function(item)
+      actions.insert_link(item.uuid, item.title)
+    end,
+    preview = file_preview,
+    helpline = " CR:insert link  q:close",
+  })
+end
+
 --- Backlinks picker - show notes that link to a specific note
 ---@param opts table|nil Options (uuid/identifier, or uses current buffer)
 function M.backlinks(opts)

--- a/lua/holon/zk/pickers.lua
+++ b/lua/holon/zk/pickers.lua
@@ -439,6 +439,16 @@ function M.indexes(opts)
     end
   end
 
+  local insert_handler = function()
+    local sel = picker.get_selected()
+    if sel then
+      picker.close()
+      vim.schedule(function()
+        actions.insert_link(sel.uuid, sel.title)
+      end)
+    end
+  end
+
   picker.open({
     title = "Holon: Index Notes",
     items = items,
@@ -449,10 +459,10 @@ function M.indexes(opts)
     end,
     preview = file_preview,
     mappings = {
-      n = { ["<Tab>"] = tab_handler },
-      i = { ["<Tab>"] = tab_handler },
+      n = { ["<Tab>"] = tab_handler, ["l"] = insert_handler },
+      i = { ["<Tab>"] = tab_handler, ["<C-l>"] = insert_handler },
     },
-    helpline = " CR:open  Tab:links  q:close",
+    helpline = " CR:open  Tab:links  l:link  q:close",
   })
 end
 
@@ -471,6 +481,16 @@ function M.index_links(opts)
   local raw = finders.find_index_links(filepath, opts)
   local entry_maker = make_entry.make_index_link_entry(opts)
   local items = build_items(raw, entry_maker)
+
+  local insert_handler = function()
+    local sel = picker.get_selected()
+    if sel and sel.exists then
+      picker.close()
+      vim.schedule(function()
+        actions.insert_link(sel.uuid, sel.display_text_raw)
+      end)
+    end
+  end
 
   picker.open({
     title = "Holon: Links from " .. utils.truncate(title, 30),
@@ -491,9 +511,11 @@ function M.index_links(opts)
           picker.close()
           M.indexes()
         end,
+        ["l"] = insert_handler,
       },
+      i = { ["<C-l>"] = insert_handler },
     },
-    helpline = " CR:open  BS:back  q:close",
+    helpline = " CR:open  BS:back  l:link  q:close",
   })
 end
 


### PR DESCRIPTION
Closes #2

## Summary

- Add `M.insert_link_picker()` to `pickers.lua`: a notes picker where `<CR>` inserts the selected note as a wikilink at the cursor position in the originating buffer
- Add `l` keymap to the link browser (`link_browser.lua`) that closes the browser and opens the insert-link picker
- Add `l` keymap to the GTD board (`board.lua`) with the same behavior
- Update all helpline strings to show `l:link`

## How it works

When `l` is pressed in either view:
1. The view is closed, returning focus to the original editing buffer
2. `vim.schedule` opens the insert-link picker on top of the original buffer
3. Selecting a note with `<CR>` inserts `[[UUID|Title]]` at the cursor position

## Test plan

- [x] Open link browser, press `l`, confirm notes picker opens with title "Holon: Insert Link"
- [x] Select a note with `<CR>`, confirm wikilink is inserted at cursor in the original buffer
- [x] Same test for GTD board
- [x] Confirm `l:link` appears in helpline of both views