### PR TITLE
fix: restore originating window on close to fix split-pane focus

### DIFF
--- a/lua/holon/gtd/board.lua
+++ b/lua/holon/gtd/board.lua
@@ -885,6 +885,8 @@ end
 
 --- Open the GTD board
 function M.open()
+  local origin_win = vim.api.nvim_get_current_win()
+
   if board then
     M.close()
   end
@@ -893,6 +895,7 @@ function M.open()
   gtd_state.load(state)
 
   board = create_layout(state)
+  board.origin_win = origin_win
 
   -- Setup keymaps
   setup_keymaps(board.bufs.tasks)
@@ -913,9 +916,15 @@ function M.close()
     return
   end
 
+  local origin_win = board.origin_win
+
   utils.close_float_wins(board.wins)
 
   board = nil
+
+  if origin_win and vim.api.nvim_win_is_valid(origin_win) then
+    vim.api.nvim_set_current_win(origin_win)
+  end
 end
 
 return M

--- a/lua/holon/picker.lua
+++ b/lua/holon/picker.lua
@@ -473,9 +473,15 @@ function M.close()
     picker.debounce_timer:close()
   end
 
+  local origin_win = picker.origin_win
+
   utils.close_float_wins(picker.wins)
 
   picker = nil
+
+  if origin_win and vim.api.nvim_win_is_valid(origin_win) then
+    vim.api.nvim_set_current_win(origin_win)
+  end
 end
 
 --- Open a picker
@@ -491,6 +497,8 @@ end
 ---  dynamic_source: fn(query) -> table[] - dynamic item source (for grep)
 ---  helpline: string - help text
 function M.open(cfg)
+  local origin_win = vim.api.nvim_get_current_win()
+
   if picker then
     M.close()
   end
@@ -505,6 +513,7 @@ function M.open(cfg)
     cursor = 1,
     marked = {},
     bufs = {},
+    origin_win = origin_win,
     wins = {},
   }
 

--- a/lua/holon/zk/link_browser.lua
+++ b/lua/holon/zk/link_browser.lua
@@ -319,6 +319,8 @@ end
 --- Open the Link Browser
 ---@param filepath string|nil Starting file path (default: current buffer)
 function M.open(filepath)
+  local origin_win = vim.api.nvim_get_current_win()
+
   if browser then
     M.close()
   end
@@ -352,6 +354,7 @@ function M.open(filepath)
     bufs = {},
     wins = {},
     list_width = list_w,
+    origin_win = origin_win,
   }
 
   -- List panel (left)
@@ -437,9 +440,15 @@ end
 function M.close()
   if not browser then return end
 
+  local origin_win = browser.origin_win
+
   utils.close_float_wins(browser.wins)
 
   browser = nil
+
+  if origin_win and vim.api.nvim_win_is_valid(origin_win) then
+    vim.api.nvim_set_current_win(origin_win)
+  end
 end
 
 return M


### PR DESCRIPTION
Fixes #4

## Root cause

`M.open()` did not record the active window, so when float windows were closed `M.close()` left Neovim to pick the next focused window — which was always the first non-float window (left pane).

## Fix

In each component's `M.open()`, save `vim.api.nvim_get_current_win()` as `origin_win`. In `M.close()`, call `vim.api.nvim_set_current_win(origin_win)` after destroying the float windows.

## Affected files

| File | Change |
|------|--------|
| `lua/holon/picker.lua` | Save/restore `origin_win` in `state` |
| `lua/holon/zk/link_browser.lua` | Save/restore `origin_win` in `browser` |
| `lua/holon/gtd/board.lua` | Save/restore `origin_win` in `board` |

## Test plan

- [x] Open a note in the right pane of a vertical split, open a picker, select a note with CR — confirm it opens in the right pane
- [x] Same test for link insertion with `l`
- [x] Same test for link browser (`o:open`)
- [x] Same test for GTD board (`CR:open`)
- [x] Confirm left-pane focus still works when the left pane was the origin